### PR TITLE
all: retrofit under io.orijtech.integrations.ocjdbc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ buildscript {
     }
 }
 
-def opencensusVersion = '0.21.0'
+def opencensusVersion = '0.24.0'
 def errorProneVersion = '2.3.1'
 def findBugsJsr305Version = '3.0.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: "net.ltgt.errorprone"
 apply plugin: "signing"
 
 group = "io.orijtech.integrations"
-version = "0.0.2" // CURRENT_OCJDBC_VERSION
+version = "0.0.4" // CURRENT_OCJDBC_VERSION
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -38,7 +38,7 @@ buildscript {
     }
 }
 
-def opencensusVersion = '0.16.1'
+def opencensusVersion = '0.21.0'
 def errorProneVersion = '2.3.1'
 def findBugsJsr305Version = '3.0.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'maven'
 apply plugin: "net.ltgt.errorprone"
 apply plugin: "signing"
 
-group = "io.opencensus.integration"
+group = "io.orijtech.integrations"
 version = "0.0.2" // CURRENT_OCJDBC_VERSION
 
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: "net.ltgt.errorprone"
 apply plugin: "signing"
 
 group = "io.orijtech.integrations"
-version = "0.0.4" // CURRENT_OCJDBC_VERSION
+version = "0.0.5" // CURRENT_OCJDBC_VERSION
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = "opencensus-jdbc"
+rootProject.name = "ocjdbc"

--- a/src/main/java/io/opencensus/integration/jdbc/Observability.java
+++ b/src/main/java/io/opencensus/integration/jdbc/Observability.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.opencensus.integration.jdbc;
+package io.orijtech.integrations.ocjdbc;
 
 import io.opencensus.common.Scope;
 import io.opencensus.stats.Aggregation;

--- a/src/main/java/io/opencensus/integration/jdbc/Observability.java
+++ b/src/main/java/io/opencensus/integration/jdbc/Observability.java
@@ -27,6 +27,8 @@ import io.opencensus.stats.ViewManager;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagContextBuilder;
 import io.opencensus.tags.TagKey;
+import io.opencensus.tags.TagMetadata;
+import io.opencensus.tags.TagMetadata.TagTtl;
 import io.opencensus.tags.TagValue;
 import io.opencensus.tags.Tagger;
 import io.opencensus.tags.Tags;
@@ -107,6 +109,8 @@ public final class Observability {
                   500000.0)));
 
   static final Aggregation COUNT = Aggregation.Count.create();
+  static final TagMetadata TAG_METADATA_TTL_UNLIMITED =
+      TagMetadata.create(TagTtl.UNLIMITED_PROPAGATION);
 
   static final View SQL_CLIENT_LATENCY_VIEW =
       View.create(
@@ -190,13 +194,15 @@ public final class Observability {
         // Finally record the latency of the entire call,
         // as well as "status": "OK" for non-error calls.
         TagContextBuilder tagContextBuilder = tagger.currentBuilder();
-        tagContextBuilder.put(JAVA_SQL_METHOD, TagValue.create(this.method));
+        tagContextBuilder.put(
+            JAVA_SQL_METHOD, TagValue.create(this.method), TAG_METADATA_TTL_UNLIMITED);
 
         if (recordedError == null) {
-          tagContextBuilder.put(JAVA_SQL_STATUS, VALUE_OK);
+          tagContextBuilder.put(JAVA_SQL_STATUS, VALUE_OK, TAG_METADATA_TTL_UNLIMITED);
         } else {
-          tagContextBuilder.put(JAVA_SQL_ERROR, TagValue.create(recordedError));
-          tagContextBuilder.put(JAVA_SQL_STATUS, VALUE_ERROR);
+          tagContextBuilder.put(
+              JAVA_SQL_ERROR, TagValue.create(recordedError), TAG_METADATA_TTL_UNLIMITED);
+          tagContextBuilder.put(JAVA_SQL_STATUS, VALUE_ERROR, TAG_METADATA_TTL_UNLIMITED);
         }
 
         long totalTimeNs = System.nanoTime() - this.startTimeNs;

--- a/src/main/java/io/opencensus/integration/jdbc/OcWrapCallableStatement.java
+++ b/src/main/java/io/opencensus/integration/jdbc/OcWrapCallableStatement.java
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.opencensus.integration.jdbc;
+package io.orijtech.integrations.ocjdbc;
 
 import io.opencensus.common.Scope;
-import io.opencensus.integration.jdbc.Observability.TraceOption;
-import io.opencensus.integration.jdbc.Observability.TrackingOperation;
+import io.orijtech.integrations.ocjdbc.Observability.TraceOption;
+import io.orijtech.integrations.ocjdbc.Observability.TrackingOperation;
 import java.sql.CallableStatement;
 import java.sql.SQLException;
 import java.util.EnumSet;

--- a/src/main/java/io/opencensus/integration/jdbc/OcWrapConnection.java
+++ b/src/main/java/io/opencensus/integration/jdbc/OcWrapConnection.java
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.opencensus.integration.jdbc;
+package io.orijtech.integrations.ocjdbc;
 
 import io.opencensus.common.Scope;
-import io.opencensus.integration.jdbc.Observability.TraceOption;
-import io.opencensus.integration.jdbc.Observability.TrackingOperation;
+import io.orijtech.integrations.ocjdbc.Observability.TraceOption;
+import io.orijtech.integrations.ocjdbc.Observability.TrackingOperation;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.EnumSet;

--- a/src/main/java/io/opencensus/integration/jdbc/OcWrapDataSource.java
+++ b/src/main/java/io/opencensus/integration/jdbc/OcWrapDataSource.java
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.opencensus.integration.jdbc;
+package io.orijtech.integrations.ocjdbc;
 
-import io.opencensus.integration.jdbc.Observability.TraceOption;
+import io.orijtech.integrations.ocjdbc.Observability.TraceOption;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/src/main/java/io/opencensus/integration/jdbc/OcWrapDriver.java
+++ b/src/main/java/io/opencensus/integration/jdbc/OcWrapDriver.java
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.opencensus.integration.jdbc;
+package io.orijtech.integrations.ocjdbc;
 
 import io.opencensus.common.Scope;
-import io.opencensus.integration.jdbc.Observability.TraceOption;
-import io.opencensus.integration.jdbc.Observability.TrackingOperation;
+import io.orijtech.integrations.ocjdbc.Observability.TraceOption;
+import io.orijtech.integrations.ocjdbc.Observability.TrackingOperation;
 import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;

--- a/src/main/java/io/opencensus/integration/jdbc/OcWrapPreparedStatement.java
+++ b/src/main/java/io/opencensus/integration/jdbc/OcWrapPreparedStatement.java
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.opencensus.integration.jdbc;
+package io.orijtech.integrations.ocjdbc;
 
 import io.opencensus.common.Scope;
-import io.opencensus.integration.jdbc.Observability.TraceOption;
-import io.opencensus.integration.jdbc.Observability.TrackingOperation;
+import io.orijtech.integrations.ocjdbc.Observability.TraceOption;
+import io.orijtech.integrations.ocjdbc.Observability.TrackingOperation;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.EnumSet;

--- a/src/main/java/io/opencensus/integration/jdbc/OcWrapResultSet.java
+++ b/src/main/java/io/opencensus/integration/jdbc/OcWrapResultSet.java
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.opencensus.integration.jdbc;
+package io.orijtech.integrations.ocjdbc;
 
 import io.opencensus.common.Scope;
-import io.opencensus.integration.jdbc.Observability.TrackingOperation;
+import io.orijtech.integrations.ocjdbc.Observability.TrackingOperation;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 

--- a/src/main/java/io/opencensus/integration/jdbc/OcWrapStatement.java
+++ b/src/main/java/io/opencensus/integration/jdbc/OcWrapStatement.java
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.opencensus.integration.jdbc;
+package io.orijtech.integrations.ocjdbc;
 
 import io.opencensus.common.Scope;
-import io.opencensus.integration.jdbc.Observability.TraceOption;
-import io.opencensus.integration.jdbc.Observability.TrackingOperation;
+import io.orijtech.integrations.ocjdbc.Observability.TraceOption;
+import io.orijtech.integrations.ocjdbc.Observability.TrackingOperation;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.EnumSet;

--- a/src/test/java/io/opencensus/integration/jdbc/ObservabilityTest.java
+++ b/src/test/java/io/opencensus/integration/jdbc/ObservabilityTest.java
@@ -31,9 +31,11 @@ import io.opencensus.stats.ViewManager;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagContextBuilder;
 import io.opencensus.tags.TagKey;
+import io.opencensus.tags.TagMetadata;
 import io.opencensus.tags.TagValue;
 import io.opencensus.tags.Tagger;
 import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.BlankSpan;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanBuilder;
 import io.opencensus.trace.Status;
@@ -68,7 +70,9 @@ public class ObservabilityTest {
     MockitoAnnotations.initMocks(this);
     Mockito.doNothing().when(mockViewManager).registerView(any(View.class));
     Mockito.when(mockTagger.currentBuilder()).thenReturn(mockTagContextBuilder);
-    Mockito.when(mockTagContextBuilder.put(any(TagKey.class), any(TagValue.class)))
+    Mockito.when(
+            mockTagContextBuilder.put(
+                any(TagKey.class), any(TagValue.class), any(TagMetadata.class)))
         .thenReturn(mockTagContextBuilder);
     Mockito.when(mockTagContextBuilder.build()).thenReturn(mockTagContext);
     Mockito.when(mockStatsRecorder.newMeasureMap()).thenReturn(mockMeasureMap);
@@ -148,7 +152,8 @@ public class ObservabilityTest {
     TrackingOperation trackingOperation =
         new TrackingOperation("method", "update", mockStatsRecorder, mockTagger, mockTracer);
     trackingOperation.withSpan();
-    Mockito.verify(mockTracer, Mockito.times(1)).spanBuilderWithExplicitParent("method", null);
+    Mockito.verify(mockTracer, Mockito.times(1))
+        .spanBuilderWithExplicitParent("method", BlankSpan.INSTANCE);
     Mockito.verify(mockSpanBuilder, Mockito.times(1)).startSpan();
     Mockito.verify(mockSpan, Mockito.times(1))
         .putAttribute("sql", AttributeValue.stringAttributeValue("update"));
@@ -161,9 +166,15 @@ public class ObservabilityTest {
     trackingOperation.end();
     Mockito.verify(mockTagger, Mockito.times(1)).currentBuilder();
     Mockito.verify(mockTagContextBuilder, Mockito.times(1))
-        .put(eq(Observability.JAVA_SQL_METHOD), eq(TagValue.create("method")));
+        .put(
+            eq(Observability.JAVA_SQL_METHOD),
+            eq(TagValue.create("method")),
+            eq(Observability.TAG_METADATA_TTL_UNLIMITED));
     Mockito.verify(mockTagContextBuilder, Mockito.times(1))
-        .put(eq(Observability.JAVA_SQL_STATUS), eq(Observability.VALUE_OK));
+        .put(
+            eq(Observability.JAVA_SQL_STATUS),
+            eq(Observability.VALUE_OK),
+            eq(Observability.TAG_METADATA_TTL_UNLIMITED));
     Mockito.verify(mockStatsRecorder, Mockito.times(1)).newMeasureMap();
     Mockito.verify(mockMeasureMap, Mockito.times(1))
         .put(eq(Observability.MEASURE_LATENCY_MS), anyDouble());
@@ -180,11 +191,20 @@ public class ObservabilityTest {
     trackingOperation.end();
     Mockito.verify(mockTagger, Mockito.times(1)).currentBuilder();
     Mockito.verify(mockTagContextBuilder, Mockito.times(1))
-        .put(eq(Observability.JAVA_SQL_METHOD), eq(TagValue.create("method")));
+        .put(
+            eq(Observability.JAVA_SQL_METHOD),
+            eq(TagValue.create("method")),
+            eq(Observability.TAG_METADATA_TTL_UNLIMITED));
     Mockito.verify(mockTagContextBuilder, Mockito.times(1))
-        .put(eq(Observability.JAVA_SQL_ERROR), eq(TagValue.create(exception.toString())));
+        .put(
+            eq(Observability.JAVA_SQL_ERROR),
+            eq(TagValue.create(exception.toString())),
+            eq(Observability.TAG_METADATA_TTL_UNLIMITED));
     Mockito.verify(mockTagContextBuilder, Mockito.times(1))
-        .put(eq(Observability.JAVA_SQL_STATUS), eq(Observability.VALUE_ERROR));
+        .put(
+            eq(Observability.JAVA_SQL_STATUS),
+            eq(Observability.VALUE_ERROR),
+            eq(Observability.TAG_METADATA_TTL_UNLIMITED));
     Mockito.verify(mockSpan, Mockito.times(1))
         .setStatus(eq(Status.UNKNOWN.withDescription(exception.toString())));
     Mockito.verify(mockStatsRecorder, Mockito.times(1)).newMeasureMap();

--- a/src/test/java/io/opencensus/integration/jdbc/ObservabilityTest.java
+++ b/src/test/java/io/opencensus/integration/jdbc/ObservabilityTest.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.opencensus.integration.jdbc;
+package io.orijtech.integrations.ocjdbc;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Matchers.any;
@@ -21,7 +21,6 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 
-import io.opencensus.integration.jdbc.Observability.TrackingOperation;
 import io.opencensus.stats.Aggregation.Distribution;
 import io.opencensus.stats.BucketBoundaries;
 import io.opencensus.stats.Measure.MeasureDouble;
@@ -39,6 +38,7 @@ import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanBuilder;
 import io.opencensus.trace.Status;
 import io.opencensus.trace.Tracer;
+import io.orijtech.integrations.ocjdbc.Observability.TrackingOperation;
 import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/io/opencensus/integration/jdbc/OcWrapDataSourceTest.java
+++ b/src/test/java/io/opencensus/integration/jdbc/OcWrapDataSourceTest.java
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.opencensus.integration.jdbc;
+package io.orijtech.integrations.ocjdbc;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.opencensus.integration.jdbc.Observability.TraceOption;
+import io.orijtech.integrations.ocjdbc.Observability.TraceOption;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.EnumSet;


### PR DESCRIPTION
Retrofit this package under
    "io.orijtech.integrations.ocjdbc"
instead of
    "io.opencensus.integration.jdbc"

because publishing changes under the official OpenCensus
artifact group is a source of contention due to the OpenCensus Java
team not wanting to have to maintain integrations for life but also
the process of publishing is highly bureaucratic.
Also we've waited for more than 3 months for a single release which
has stalled usage, promotion, feedback and marketing of this integration
as per:
* https://github.com/census-ecosystem/opencensus-java-jdbc/issues/32
* https://github.com/census-ecosystem/opencensus-java-jdbc/issues/56
* https://github.com/census-instrumentation/opencensus-website/issues/527

This package to be published is maintained under good faith for the entire OpenCensus
community and the licenses all stand; just that the artifact is now
being published under "io.orijtech.integrations.ocjdbc" which guts out
on the previously mentioned bureaucracy, indefinite stalls in publishing
and puts this integration into the hands of users.