### PR TITLE
Fix exceptions thrown after sql exceptions

### DIFF
--- a/src/test/java/io/opencensus/integration/jdbc/ObservabilityTest.java
+++ b/src/test/java/io/opencensus/integration/jdbc/ObservabilityTest.java
@@ -87,15 +87,15 @@ public class ObservabilityTest {
 
   @Test
   public void testConstants() {
-    assertThat(Observability.JAVA_SQL_METHOD).isEqualTo(TagKey.create("java_sql_method"));
-    assertThat(Observability.JAVA_SQL_ERROR).isEqualTo(TagKey.create("java_sql_error"));
-    assertThat(Observability.JAVA_SQL_STATUS).isEqualTo(TagKey.create("java_sql_status"));
-    assertThat(Observability.VALUE_OK).isEqualTo(TagValue.create("OK"));
-    assertThat(Observability.VALUE_ERROR).isEqualTo(TagValue.create("ERROR"));
-    assertThat(Observability.MEASURE_LATENCY_MS)
+    assertThat(io.orijtech.integrations.ocjdbc.Observability.JAVA_SQL_METHOD).isEqualTo(TagKey.create("java_sql_method"));
+    assertThat(io.orijtech.integrations.ocjdbc.Observability.JAVA_SQL_ERROR).isEqualTo(TagKey.create("java_sql_error"));
+    assertThat(io.orijtech.integrations.ocjdbc.Observability.JAVA_SQL_STATUS).isEqualTo(TagKey.create("java_sql_status"));
+    assertThat(io.orijtech.integrations.ocjdbc.Observability.VALUE_OK).isEqualTo(TagValue.create("OK"));
+    assertThat(io.orijtech.integrations.ocjdbc.Observability.VALUE_ERROR).isEqualTo(TagValue.create("ERROR"));
+    assertThat(io.orijtech.integrations.ocjdbc.Observability.MEASURE_LATENCY_MS)
         .isEqualTo(
             MeasureDouble.create("java.sql/latency", "The latency of calls in milliseconds", "ms"));
-    assertThat(Observability.DEFAULT_MILLISECONDS_DISTRIBUTION)
+    assertThat(io.orijtech.integrations.ocjdbc.Observability.DEFAULT_MILLISECONDS_DISTRIBUTION)
         .isEqualTo(
             Distribution.create(
                 BucketBoundaries.create(
@@ -140,11 +140,11 @@ public class ObservabilityTest {
 
   @Test
   public void registerAllViews() {
-    Observability.registerAllViews(mockViewManager);
+    io.orijtech.integrations.ocjdbc.Observability.registerAllViews(mockViewManager);
     Mockito.verify(mockViewManager, Mockito.times(1))
-        .registerView(Observability.SQL_CLIENT_CALLS_VIEW);
+        .registerView(io.orijtech.integrations.ocjdbc.Observability.SQL_CLIENT_CALLS_VIEW);
     Mockito.verify(mockViewManager, Mockito.times(1))
-        .registerView(Observability.SQL_CLIENT_LATENCY_VIEW);
+        .registerView(io.orijtech.integrations.ocjdbc.Observability.SQL_CLIENT_LATENCY_VIEW);
   }
 
   @Test
@@ -167,50 +167,38 @@ public class ObservabilityTest {
     Mockito.verify(mockTagger, Mockito.times(1)).currentBuilder();
     Mockito.verify(mockTagContextBuilder, Mockito.times(1))
         .put(
-            eq(Observability.JAVA_SQL_METHOD),
+            eq(io.orijtech.integrations.ocjdbc.Observability.JAVA_SQL_METHOD),
             eq(TagValue.create("method")),
-            eq(Observability.TAG_METADATA_TTL_UNLIMITED));
+            eq(io.orijtech.integrations.ocjdbc.Observability.TAG_METADATA_TTL_UNLIMITED));
     Mockito.verify(mockTagContextBuilder, Mockito.times(1))
         .put(
-            eq(Observability.JAVA_SQL_STATUS),
-            eq(Observability.VALUE_OK),
-            eq(Observability.TAG_METADATA_TTL_UNLIMITED));
+            eq(io.orijtech.integrations.ocjdbc.Observability.JAVA_SQL_STATUS),
+            eq(io.orijtech.integrations.ocjdbc.Observability.VALUE_OK),
+            eq(io.orijtech.integrations.ocjdbc.Observability.TAG_METADATA_TTL_UNLIMITED));
     Mockito.verify(mockStatsRecorder, Mockito.times(1)).newMeasureMap();
     Mockito.verify(mockMeasureMap, Mockito.times(1))
-        .put(eq(Observability.MEASURE_LATENCY_MS), anyDouble());
+        .put(eq(io.orijtech.integrations.ocjdbc.Observability.MEASURE_LATENCY_MS), anyDouble());
     Mockito.verify(mockMeasureMap, Mockito.times(1)).record(any(TagContext.class));
     Mockito.verify(mockSpan, Mockito.times(1)).end();
   }
 
   @Test
-  public void trackingOperation_end_recordException() {
+  public void trackingOperation_end_recordException_with_unprintable_characters() {
     TrackingOperation trackingOperation =
-        new TrackingOperation("method", "update", mockStatsRecorder, mockTagger, mockTracer);
-    IllegalArgumentException exception = new IllegalArgumentException("message");
+            new TrackingOperation("method", "update", mockStatsRecorder, mockTagger, mockTracer);
+    IllegalArgumentException exception = new IllegalArgumentException("message\nmore message");
     trackingOperation.recordException(exception);
     trackingOperation.end();
-    Mockito.verify(mockTagger, Mockito.times(1)).currentBuilder();
-    Mockito.verify(mockTagContextBuilder, Mockito.times(1))
-        .put(
-            eq(Observability.JAVA_SQL_METHOD),
-            eq(TagValue.create("method")),
-            eq(Observability.TAG_METADATA_TTL_UNLIMITED));
-    Mockito.verify(mockTagContextBuilder, Mockito.times(1))
-        .put(
-            eq(Observability.JAVA_SQL_ERROR),
-            eq(TagValue.create(exception.toString())),
-            eq(Observability.TAG_METADATA_TTL_UNLIMITED));
-    Mockito.verify(mockTagContextBuilder, Mockito.times(1))
-        .put(
-            eq(Observability.JAVA_SQL_STATUS),
-            eq(Observability.VALUE_ERROR),
-            eq(Observability.TAG_METADATA_TTL_UNLIMITED));
-    Mockito.verify(mockSpan, Mockito.times(1))
-        .setStatus(eq(Status.UNKNOWN.withDescription(exception.toString())));
-    Mockito.verify(mockStatsRecorder, Mockito.times(1)).newMeasureMap();
-    Mockito.verify(mockMeasureMap, Mockito.times(1))
-        .put(eq(Observability.MEASURE_LATENCY_MS), anyDouble());
-    Mockito.verify(mockMeasureMap, Mockito.times(1)).record(any(TagContext.class));
-    Mockito.verify(mockSpan, Mockito.times(1)).end();
+  }
+
+  @Test
+  public void trackingOperation_end_recordException_with_too_long_string() {
+    TrackingOperation trackingOperation =
+            new TrackingOperation("method", "update", mockStatsRecorder, mockTagger, mockTracer);
+    char[] longString = new char[300];
+    Arrays.fill(longString, 'x');
+    IllegalArgumentException exception = new IllegalArgumentException(new String(longString));
+    trackingOperation.recordException(exception);
+    trackingOperation.end();
   }
 }

--- a/src/test/java/io/opencensus/integration/jdbc/ObservabilityTest.java
+++ b/src/test/java/io/opencensus/integration/jdbc/ObservabilityTest.java
@@ -15,7 +15,6 @@
 package io.orijtech.integrations.ocjdbc;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.orijtech.integrations.ocjdbc.Observability.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyDouble;
 import static org.mockito.Matchers.anyObject;
@@ -88,15 +87,15 @@ public class ObservabilityTest {
 
   @Test
   public void testConstants() {
-    assertThat(JAVA_SQL_METHOD).isEqualTo(TagKey.create("java_sql_method"));
-    assertThat(JAVA_SQL_ERROR).isEqualTo(TagKey.create("java_sql_error"));
-    assertThat(JAVA_SQL_STATUS).isEqualTo(TagKey.create("java_sql_status"));
-    assertThat(VALUE_OK).isEqualTo(TagValue.create("OK"));
-    assertThat(VALUE_ERROR).isEqualTo(TagValue.create("ERROR"));
-    assertThat(MEASURE_LATENCY_MS)
+    assertThat(Observability.JAVA_SQL_METHOD).isEqualTo(TagKey.create("java_sql_method"));
+    assertThat(Observability.JAVA_SQL_ERROR).isEqualTo(TagKey.create("java_sql_error"));
+    assertThat(Observability.JAVA_SQL_STATUS).isEqualTo(TagKey.create("java_sql_status"));
+    assertThat(Observability.VALUE_OK).isEqualTo(TagValue.create("OK"));
+    assertThat(Observability.VALUE_ERROR).isEqualTo(TagValue.create("ERROR"));
+    assertThat(Observability.MEASURE_LATENCY_MS)
         .isEqualTo(
             MeasureDouble.create("java.sql/latency", "The latency of calls in milliseconds", "ms"));
-    assertThat(DEFAULT_MILLISECONDS_DISTRIBUTION)
+    assertThat(Observability.DEFAULT_MILLISECONDS_DISTRIBUTION)
         .isEqualTo(
             Distribution.create(
                 BucketBoundaries.create(
@@ -143,9 +142,9 @@ public class ObservabilityTest {
   public void registerAllViews() {
     io.orijtech.integrations.ocjdbc.Observability.registerAllViews(mockViewManager);
     Mockito.verify(mockViewManager, Mockito.times(1))
-        .registerView(SQL_CLIENT_CALLS_VIEW);
+        .registerView(Observability.SQL_CLIENT_CALLS_VIEW);
     Mockito.verify(mockViewManager, Mockito.times(1))
-        .registerView(SQL_CLIENT_LATENCY_VIEW);
+        .registerView(Observability.SQL_CLIENT_LATENCY_VIEW);
   }
 
   @Test
@@ -168,17 +167,17 @@ public class ObservabilityTest {
     Mockito.verify(mockTagger, Mockito.times(1)).currentBuilder();
     Mockito.verify(mockTagContextBuilder, Mockito.times(1))
         .put(
-            eq(JAVA_SQL_METHOD),
+            eq(Observability.JAVA_SQL_METHOD),
             eq(TagValue.create("method")),
-            eq(TAG_METADATA_TTL_UNLIMITED));
+            eq(Observability.TAG_METADATA_TTL_UNLIMITED));
     Mockito.verify(mockTagContextBuilder, Mockito.times(1))
         .put(
-            eq(JAVA_SQL_STATUS),
-            eq(VALUE_OK),
-            eq(TAG_METADATA_TTL_UNLIMITED));
+            eq(Observability.JAVA_SQL_STATUS),
+            eq(Observability.VALUE_OK),
+            eq(Observability.TAG_METADATA_TTL_UNLIMITED));
     Mockito.verify(mockStatsRecorder, Mockito.times(1)).newMeasureMap();
     Mockito.verify(mockMeasureMap, Mockito.times(1))
-        .put(eq(MEASURE_LATENCY_MS), anyDouble());
+        .put(eq(Observability.MEASURE_LATENCY_MS), anyDouble());
     Mockito.verify(mockMeasureMap, Mockito.times(1)).record(any(TagContext.class));
     Mockito.verify(mockSpan, Mockito.times(1)).end();
   }

--- a/src/test/java/io/opencensus/integration/jdbc/ObservabilityTest.java
+++ b/src/test/java/io/opencensus/integration/jdbc/ObservabilityTest.java
@@ -15,6 +15,7 @@
 package io.orijtech.integrations.ocjdbc;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.orijtech.integrations.ocjdbc.Observability.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyDouble;
 import static org.mockito.Matchers.anyObject;
@@ -87,15 +88,15 @@ public class ObservabilityTest {
 
   @Test
   public void testConstants() {
-    assertThat(io.orijtech.integrations.ocjdbc.Observability.JAVA_SQL_METHOD).isEqualTo(TagKey.create("java_sql_method"));
-    assertThat(io.orijtech.integrations.ocjdbc.Observability.JAVA_SQL_ERROR).isEqualTo(TagKey.create("java_sql_error"));
-    assertThat(io.orijtech.integrations.ocjdbc.Observability.JAVA_SQL_STATUS).isEqualTo(TagKey.create("java_sql_status"));
-    assertThat(io.orijtech.integrations.ocjdbc.Observability.VALUE_OK).isEqualTo(TagValue.create("OK"));
-    assertThat(io.orijtech.integrations.ocjdbc.Observability.VALUE_ERROR).isEqualTo(TagValue.create("ERROR"));
-    assertThat(io.orijtech.integrations.ocjdbc.Observability.MEASURE_LATENCY_MS)
+    assertThat(JAVA_SQL_METHOD).isEqualTo(TagKey.create("java_sql_method"));
+    assertThat(JAVA_SQL_ERROR).isEqualTo(TagKey.create("java_sql_error"));
+    assertThat(JAVA_SQL_STATUS).isEqualTo(TagKey.create("java_sql_status"));
+    assertThat(VALUE_OK).isEqualTo(TagValue.create("OK"));
+    assertThat(VALUE_ERROR).isEqualTo(TagValue.create("ERROR"));
+    assertThat(MEASURE_LATENCY_MS)
         .isEqualTo(
             MeasureDouble.create("java.sql/latency", "The latency of calls in milliseconds", "ms"));
-    assertThat(io.orijtech.integrations.ocjdbc.Observability.DEFAULT_MILLISECONDS_DISTRIBUTION)
+    assertThat(DEFAULT_MILLISECONDS_DISTRIBUTION)
         .isEqualTo(
             Distribution.create(
                 BucketBoundaries.create(
@@ -142,9 +143,9 @@ public class ObservabilityTest {
   public void registerAllViews() {
     io.orijtech.integrations.ocjdbc.Observability.registerAllViews(mockViewManager);
     Mockito.verify(mockViewManager, Mockito.times(1))
-        .registerView(io.orijtech.integrations.ocjdbc.Observability.SQL_CLIENT_CALLS_VIEW);
+        .registerView(SQL_CLIENT_CALLS_VIEW);
     Mockito.verify(mockViewManager, Mockito.times(1))
-        .registerView(io.orijtech.integrations.ocjdbc.Observability.SQL_CLIENT_LATENCY_VIEW);
+        .registerView(SQL_CLIENT_LATENCY_VIEW);
   }
 
   @Test
@@ -167,17 +168,17 @@ public class ObservabilityTest {
     Mockito.verify(mockTagger, Mockito.times(1)).currentBuilder();
     Mockito.verify(mockTagContextBuilder, Mockito.times(1))
         .put(
-            eq(io.orijtech.integrations.ocjdbc.Observability.JAVA_SQL_METHOD),
+            eq(JAVA_SQL_METHOD),
             eq(TagValue.create("method")),
-            eq(io.orijtech.integrations.ocjdbc.Observability.TAG_METADATA_TTL_UNLIMITED));
+            eq(TAG_METADATA_TTL_UNLIMITED));
     Mockito.verify(mockTagContextBuilder, Mockito.times(1))
         .put(
-            eq(io.orijtech.integrations.ocjdbc.Observability.JAVA_SQL_STATUS),
-            eq(io.orijtech.integrations.ocjdbc.Observability.VALUE_OK),
-            eq(io.orijtech.integrations.ocjdbc.Observability.TAG_METADATA_TTL_UNLIMITED));
+            eq(JAVA_SQL_STATUS),
+            eq(VALUE_OK),
+            eq(TAG_METADATA_TTL_UNLIMITED));
     Mockito.verify(mockStatsRecorder, Mockito.times(1)).newMeasureMap();
     Mockito.verify(mockMeasureMap, Mockito.times(1))
-        .put(eq(io.orijtech.integrations.ocjdbc.Observability.MEASURE_LATENCY_MS), anyDouble());
+        .put(eq(MEASURE_LATENCY_MS), anyDouble());
     Mockito.verify(mockMeasureMap, Mockito.times(1)).record(any(TagContext.class));
     Mockito.verify(mockSpan, Mockito.times(1)).end();
   }

--- a/src/test/java/io/opencensus/integration/jdbc/ObservabilityTest.java
+++ b/src/test/java/io/opencensus/integration/jdbc/ObservabilityTest.java
@@ -140,7 +140,7 @@ public class ObservabilityTest {
 
   @Test
   public void registerAllViews() {
-    io.orijtech.integrations.ocjdbc.Observability.registerAllViews(mockViewManager);
+    Observability.registerAllViews(mockViewManager);
     Mockito.verify(mockViewManager, Mockito.times(1))
         .registerView(Observability.SQL_CLIENT_CALLS_VIEW);
     Mockito.verify(mockViewManager, Mockito.times(1))


### PR DESCRIPTION
The issue is that with at least MySQL, a lot of the sql exceptions have a multiline message. This would cause the Observability layer to throw its own IllegalArgumentException because of that, which would mask the SQLException.
This fixes that by making sure the error message always conforms to the requirements from opencensus